### PR TITLE
remove need to softlink petsc module files through FFLAGS variable

### DIFF
--- a/scripts_ecse/dev_linux_amd64_gfortran_archer2_oad
+++ b/scripts_ecse/dev_linux_amd64_gfortran_archer2_oad
@@ -28,7 +28,7 @@ LIBS="$LIBS -L${MY_PETSC_DIR}/lib -lpetsc -lHYPRE -lcmumps -ldmumps -lesmumps -l
 NOOPTFLAGS='-O0'
 NOOPTFILES=''
 
-FFLAGS='-fallow-argument-mismatch'
+FFLAGS='-fallow-argument-mismatch -I${MY_PETSC_DIR}/include'
 
 if test "x$IEEE" = x ; then   #- with optimisation:
     FOPTIM='-O3'

--- a/scripts_ecse/make_archer.sh
+++ b/scripts_ecse/make_archer.sh
@@ -56,7 +56,6 @@ fi
 
 
 $MITGCM_ROOTDIR/tools/genmake2 -mods='../code' -of=../scripts/dev_linux_amd64_gfortran_archer2_oad -oad -mpi --oadsingularity="$sing_str"
-ln -s $MY_PETSC_DIR/include/*.mod .
 
 echo ----------------------LD_LIBRARY_PATH --------------------
 echo $LD_LIBRARY_PATH


### PR DESCRIPTION
This is a minor pull request. Through communication with Oliver Jahn i have been able to obviate the need for this line 

https://github.com/eCSE-MITgcm-ARCHER2/eCSE-archer2-AmundIce/blob/f75b6e2e245ac9eb2a1cc9ee17c11b282fc7d0b1/scripts_ecse/make_archer.sh#L59

which i don't really like. It seems by augmenting the FFLAGS variable in the build options file with an include command, this seems to now work without the above line (for some reason including this in the INCLUDES variable is not enough).

I have tested in my own user space but not with a fresh clone. @MikeMineter i leave it to you to decide whether to merge this!!!